### PR TITLE
2 minor changes

### DIFF
--- a/components/Condition.vue
+++ b/components/Condition.vue
@@ -9,7 +9,7 @@ const conditions = frequentlyUsedConditions.concat(lessUsedConditions)
   <v-container>
     <v-row>
       <!-- v-for 設在v-col處，由grid system去自動左右排列 -->
-      <v-col v-for="(condition, index) in conditions" :key="condition" cols="6" class="pr-0">
+      <v-col v-for="(condition, index) in conditions" :key="condition" cols="6" class="pr-0 py-1">
         <!-- color 處保留既有左右不同色的設計 -->
         <v-switch
           :label="$t(`condition.${condition}`)"

--- a/components/Condition.vue
+++ b/components/Condition.vue
@@ -1,29 +1,20 @@
 <script lang="ts" setup>
-const switchGroup1 = ['helpingHand', 'burned', 'charge', 'critical', 'powerSpot']
-const switchGroup2 = ['lightScreen', 'reflect', 'steelySpirit', 'friendGuard']
+// 改成更好讀的variable name
+const frequentlyUsedConditions = ['helpingHand', 'burned']
+const lessUsedConditions = ['charge', 'critical', 'powerSpot', 'lightScreen', 'reflect', 'steelySpirit', 'friendGuard']
+const conditions = frequentlyUsedConditions.concat(lessUsedConditions)
 </script>
 
 <template>
   <v-container>
     <v-row>
-      <v-col cols="6" class="pr-0">
+      <!-- v-for 設在v-col處，由grid system去自動左右排列 -->
+      <v-col v-for="(condition, index) in conditions" :key="condition" cols="6" class="pr-0">
+        <!-- color 處保留既有左右不同色的設計 -->
         <v-switch
-          v-for="switchInfo in switchGroup1"
-          :key="switchInfo"
-          :label="$t(`condition.${switchInfo}`)"
-          color="secondary"
-          :value="switchInfo"
-          hide-details
-          density="comfortable"
-        />
-      </v-col>
-      <v-col cols="6" class="pl-0">
-        <v-switch
-          v-for="switchInfo in switchGroup2"
-          :key="switchInfo"
-          :label="$t(`condition.${switchInfo}`)"
-          color="primary"
-          :value="switchInfo"
+          :label="$t(`condition.${condition}`)"
+          :color="index % 2 === 0 ? 'secondary' : 'primary'"
+          :value="condition"
           hide-details
           density="comfortable"
         />

--- a/components/PokemonCard.vue
+++ b/components/PokemonCard.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { abilityProps, itemsProps, movesProps } from '~/composables/useAssetKeyToContext'
-
 const show = ref(false)
 </script>
 
@@ -12,7 +10,7 @@ const show = ref(false)
       <pokemon-info />
       <pokemon-select />
       <pokemon-stat />
-      <selection list-type="Move" :convert-item-props="movesProps" />
+      <selection list-type="Move" />
       <v-card-actions>
         <v-btn
           color="purple-lighten-2"
@@ -36,10 +34,10 @@ const show = ref(false)
           <v-container class="px-0">
             <v-row>
               <v-col cols="12" sm="6" class="pb-0 pb-sm-2">
-                <selection list-type="Item" :convert-item-props="itemsProps" />
+                <selection list-type="Item" />
               </v-col>
               <v-col cols="12" sm="6" class="pb-0 pb-sm-2">
-                <selection list-type="Ability" :convert-item-props="abilityProps" />
+                <selection list-type="Ability" />
               </v-col>
             </v-row>
           </v-container>

--- a/components/Selection.vue
+++ b/components/Selection.vue
@@ -1,12 +1,10 @@
 <script setup lang="ts" generic="T extends string, U">
 import { useI18n } from 'vue-i18n'
+import { assetToPropsMapping } from '~/composables/useAssetKeyToContext'
+import { hiraToKata, romanToKana } from '~/utils/convertKana'
 
 interface ISelection {
   listType: AssetType
-  convertItemProps: (item: T, value: U) => {
-    title: string
-    subtitle: string
-  }
 }
 const props = defineProps<ISelection>()
 const { t } = useI18n()
@@ -15,7 +13,7 @@ const list = Object.keys(defaultList) as Array<T>
 const loading = ref(false)
 
 function itemProps(item: T) {
-  const oriItem = (props.convertItemProps(item, defaultList[item]))
+  const oriItem = (assetToPropsMapping[props.listType](item, defaultList[item]))
   const splitSubtitle = oriItem.subtitle.split('/')
   const i18nItem = {
     title: t(`${oriItem.title}`),

--- a/composables/useAssetKeyToContext.ts
+++ b/composables/useAssetKeyToContext.ts
@@ -11,7 +11,13 @@ export async function getAsset<T extends string, U>(assetType: AssetType) {
   return (await import(`../assets/pokemon${assetType}.json`)).default as Record<T, U>
 }
 
-export function movesProps(move: JSONKey<typeof moves>, value: JSONValue<typeof moves>) {
+export const assetToPropsMapping: Record<AssetType, (...args: any) => { title: string, subtitle: string }> = {
+  Move: movesProps,
+  Ability: abilityProps,
+  Item: itemsProps
+}
+
+function movesProps(move: JSONKey<typeof moves>, value: JSONValue<typeof moves>) {
   const { type, basePower, category } = value
   return {
     title: `move.${move}`,
@@ -19,7 +25,7 @@ export function movesProps(move: JSONKey<typeof moves>, value: JSONValue<typeof 
   }
 }
 
-export function abilityProps(ability: JSONKey<typeof abilities>, value: JSONValue<typeof abilities>) {
+function abilityProps(ability: JSONKey<typeof abilities>, value: JSONValue<typeof abilities>) {
   const { effect } = value
   return {
     title: `ability.${ability}`,
@@ -27,7 +33,7 @@ export function abilityProps(ability: JSONKey<typeof abilities>, value: JSONValu
   }
 }
 
-export function itemsProps(item: JSONKey<typeof items>, value: JSONValue<typeof items>) {
+function itemsProps(item: JSONKey<typeof items>, value: JSONValue<typeof items>) {
   const { effect } = value
   return {
     title: `item.${item}`,


### PR DESCRIPTION
- 把Selection的convertItemProps prop移除，用listType決定是哪個funciton，避免發生listType跟convertItemProps沒有對好的問題
- 調整Condition.vue
   1. 修改命名，condition1 & 2相對不知道區分原因
   2. 修改v-for位置，每個condition產生一個v-col，不用分開迴圈
   3. 承上，也讓未來如果“手動排順序”時比較好排，不會讓“順序優先的condition散落在condition 1 & 2”
