### PR TITLE
Use generic to declare prop & emit type 

### DIFF
--- a/components/TeraSelect.vue
+++ b/components/TeraSelect.vue
@@ -1,10 +1,13 @@
 <script lang="ts" setup>
 import json from '../locales/en.json'
 
-const props = defineProps({
-  teraType: String
-})
-const emit = defineEmits(['changeTeraType'])
+const props = defineProps<{
+  teraType: string
+}>()
+
+const emit = defineEmits<{
+  changeTeraType: [teraType: string]
+}>()
 
 const dialog = ref(false)
 const currentTeraType = ref(props.teraType)

--- a/components/TeraSelect.vue
+++ b/components/TeraSelect.vue
@@ -1,10 +1,13 @@
 <script lang="ts" setup>
 import json from '../locales/en.json'
 
+// 用原有寫法會判斷成optional，使用時需要多一層處理
 const props = defineProps<{
   teraType: string
 }>()
 
+// 既有寫法沒辦法讓parent知道這個event會帶什麼參數/參數type為何
+// 參考：https://vuejs.org/guide/typescript/composition-api#typing-component-emits
 const emit = defineEmits<{
   changeTeraType: [teraType: string]
 }>()


### PR DESCRIPTION
- 用原有寫法會把props判斷成optional，使用時需要多一層處理
- 既有defineEmits寫法沒辦法讓parent知道這個event會帶什麼參數/參數type為何